### PR TITLE
Update the go.mod file to upgrade cdproto on chromedp module to fix API changes and unmarshal events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,52 +5,52 @@ go 1.22
 toolchain go1.22.1
 
 require (
-	github.com/PuerkitoBio/goquery v1.9.1
-	github.com/chromedp/cdproto v0.0.0-20240312231614-1e5096e63154
-	github.com/chromedp/chromedp v0.9.5
-	github.com/gocolly/colly v1.2.0
-	github.com/google/uuid v1.6.0
-	github.com/gookit/color v1.5.4
-	github.com/gorilla/mux v1.8.1
-	github.com/hophouse/golang-whois v0.0.0-20201201134657-ef4b2ee3bb08
-	github.com/jroimartin/gocui v0.5.0
-	github.com/miekg/dns v1.1.58
-	github.com/spf13/cobra v1.8.0
-	github.com/urfave/negroni v1.0.0
-	github.com/vbauerster/mpb/v7 v7.5.3
-	golang.org/x/exp v0.0.0-20240314144324-c7f7c6466f7f
+    github.com/PuerkitoBio/goquery v1.9.1
+    github.com/chromedp/cdproto v0.0.0-20240919203636-12af5e8a671f
+    github.com/chromedp/chromedp v0.10.0
+    github.com/gocolly/colly v1.2.0
+    github.com/google/uuid v1.6.0
+    github.com/gookit/color v1.5.4
+    github.com/gorilla/mux v1.8.1
+    github.com/hophouse/golang-whois v0.0.0-20201201134657-ef4b2ee3bb08
+    github.com/jroimartin/gocui v0.5.0
+    github.com/miekg/dns v1.1.58
+    github.com/spf13/cobra v1.8.0
+    github.com/urfave/negroni v1.0.0
+    github.com/vbauerster/mpb/v7 v7.5.3
+    golang.org/x/exp v0.0.0-20240314144324-c7f7c6466f7f
 )
 
 require (
-	github.com/VividCortex/ewma v1.2.0 // indirect
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
-	github.com/andybalholm/cascadia v1.3.2 // indirect
-	github.com/antchfx/htmlquery v1.3.0 // indirect
-	github.com/antchfx/xmlquery v1.3.18 // indirect
-	github.com/antchfx/xpath v1.2.5 // indirect
-	github.com/chromedp/sysutil v1.0.0 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/gobwas/httphead v0.1.0 // indirect
-	github.com/gobwas/pool v0.2.1 // indirect
-	github.com/gobwas/ws v1.3.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/kennygrant/sanitize v1.2.4 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/nsf/termbox-go v1.1.1 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/temoto/robotstxt v1.1.2 // indirect
-	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/mod v0.16.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.19.0 // indirect
-	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
+    github.com/VividCortex/ewma v1.2.0 // indirect
+    github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
+    github.com/andybalholm/cascadia v1.3.2 // indirect
+    github.com/antchfx/htmlquery v1.3.0 // indirect
+    github.com/antchfx/xmlquery v1.3.18 // indirect
+    github.com/antchfx/xpath v1.2.5 // indirect
+    github.com/chromedp/sysutil v1.0.0 // indirect
+    github.com/gobwas/glob v0.2.3 // indirect
+    github.com/gobwas/httphead v0.1.0 // indirect
+    github.com/gobwas/pool v0.2.1 // indirect
+    github.com/gobwas/ws v1.4.0 // indirect
+    github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+    github.com/golang/protobuf v1.5.4 // indirect
+    github.com/inconshreveable/mousetrap v1.1.0 // indirect
+    github.com/josharian/intern v1.0.0 // indirect
+    github.com/kennygrant/sanitize v1.2.4 // indirect
+    github.com/mailru/easyjson v0.7.7 // indirect
+    github.com/mattn/go-runewidth v0.0.15 // indirect
+    github.com/nsf/termbox-go v1.1.1 // indirect
+    github.com/rivo/uniseg v0.4.7 // indirect
+    github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
+    github.com/spf13/pflag v1.0.5 // indirect
+    github.com/temoto/robotstxt v1.1.2 // indirect
+    github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+    golang.org/x/mod v0.16.0 // indirect
+    golang.org/x/net v0.23.0 // indirect
+    golang.org/x/sys v0.25.0 // indirect
+    golang.org/x/text v0.14.0 // indirect
+    golang.org/x/tools v0.19.0 // indirect
+    google.golang.org/appengine v1.6.8 // indirect
+    google.golang.org/protobuf v1.33.0 // indirect
 )


### PR DESCRIPTION
Update the `go.mod` to fix several API changes in Chrome. More details:
Upgrade the cdproto module to fix the issue described here: https://github.com/chromedp/chromedp/issues/1491

It fixes the following error in the screenshot feature
```ERROR: could not unmarshal event: parse error: expected string near offset```